### PR TITLE
Fix warnings

### DIFF
--- a/SteamTogether.Bot/Options/TelegramOptions.cs
+++ b/SteamTogether.Bot/Options/TelegramOptions.cs
@@ -4,5 +4,5 @@ public class TelegramOptions
 {
     public const string Telegram = "Telegram";
 
-    public string Token { get; set; }
+    public string Token { get; set; } = default!;
 }

--- a/SteamTogether.Bot/Program.cs
+++ b/SteamTogether.Bot/Program.cs
@@ -21,7 +21,8 @@ var host = Host.CreateDefaultBuilder()
             .AddHttpClient(nameof(TelegramBotClient))
             .AddTypedClient<ITelegramBotClient>((httpClient, sp) =>
             {
-                var opts = sp.GetService<IOptions<TelegramOptions>>();
+                var opts = sp.GetService<IOptions<TelegramOptions>>()
+                           ?? throw new ArgumentNullException("TelegramOptions service is null");
                 var telegramOpts = new TelegramBotClientOptions(opts.Value.Token);
                 return new TelegramBotClient(telegramOpts, httpClient);
             })


### PR DESCRIPTION
`TelegramBotClientOptions`'s `token` argument is not nullable.