### PR TITLE
Print version on startup

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,38 +34,24 @@ jobs:
 
       - name: Generate version number
         id: version
-        run: |
-          TAG=$(git describe --abbrev=0 --tags 2>/dev/null)
-          if [ -n "$TAG" ] && git describe --exact-match &>/dev/null; then
-              VERSION=$TAG
-          else
-              SHORT_SHA=$(git rev-parse --short HEAD)
-              if [ -z "$TAG" ]; then
-                  COMMITS_SINCE_BEGINNING=$(git rev-list --count HEAD 2>/dev/null)
-                  VERSION="0.0.0.$COMMITS_SINCE_BEGINNING-$SHORT_SHA"
-              else
-                  COMMITS_SINCE_TAG=$(git rev-list --count HEAD ^$TAG 2>/dev/null)
-                  VERSION="$TAG.$COMMITS_SINCE_TAG-$SHORT_SHA"
-              fi
-          fi
-          echo "::set-output name=version::$VERSION"
+        run: echo "::set-output name=version::$(scripts/version.sh)"
 
       - name: Docker Compose build
-        run: docker compose build --build-arg VERSION=${{ steps.version.outputs.version }}
+        run: docker compose build
         env:
-          DOCKER_HOST: "${{ secrets.DOCKER_HOST }}"
-          GIT_COMMIT: ${{ github.sha }}
           BOT_HEALTHCHECK__PORT: 10090
+          DOCKER_HOST: "${{ secrets.DOCKER_HOST }}"
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Docker Compose up
         run: docker compose up -d
         env:
+          BOT_HEALTHCHECK__PORT: 10090
           BOT_STEAM__APIKEY: ${{ secrets.STEAM_APIKEY }}
           BOT_TELEGRAM__TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           DOCKER_HOST: "${{ secrets.DOCKER_HOST }}"
-          GIT_COMMIT: ${{ github.sha }}
           SCRAPER_STEAM__APIKEY: ${{ secrets.STEAM_APIKEY }}
-          BOT_HEALTHCHECK__PORT: 10090
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Notify Telegram
         uses: appleboy/telegram-action@master

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,8 +32,26 @@ jobs:
           echo "${{ secrets.DOCKER_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
 
+      - name: Generate version number
+        id: version
+        run: |
+          TAG=$(git describe --abbrev=0 --tags 2>/dev/null)
+          if [ -n "$TAG" ] && git describe --exact-match &>/dev/null; then
+              VERSION=$TAG
+          else
+              SHORT_SHA=$(git rev-parse --short HEAD)
+              if [ -z "$TAG" ]; then
+                  COMMITS_SINCE_BEGINNING=$(git rev-list --count HEAD 2>/dev/null)
+                  VERSION="0.0.0.$COMMITS_SINCE_BEGINNING-$SHORT_SHA"
+              else
+                  COMMITS_SINCE_TAG=$(git rev-list --count HEAD ^$TAG 2>/dev/null)
+                  VERSION="$TAG.$COMMITS_SINCE_TAG-$SHORT_SHA"
+              fi
+          fi
+          echo "::set-output name=version::$VERSION"
+
       - name: Docker Compose build
-        run: docker compose build
+        run: docker compose build --build-arg VERSION=${{ steps.version.outputs.version }}
         env:
           DOCKER_HOST: "${{ secrets.DOCKER_HOST }}"
           GIT_COMMIT: ${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,12 @@ COPY --link SteamTogether.Scraper SteamTogether.Scraper
 
 
 FROM restore AS build-bot
+ARG VERSION=¯\_(ツ)_/¯
 RUN dotnet publish SteamTogether.Bot/SteamTogether.Bot.csproj \
     --configuration Release \
     --output /publish \
-    --no-restore
+    --no-restore \
+    /p:Version=$VERSION
 
 
 FROM runtime AS bot
@@ -44,10 +46,12 @@ ENTRYPOINT ["/app/SteamTogether.Bot"]
 
 
 FROM restore AS build-scraper
+ARG VERSION=¯\_(ツ)_/¯
 RUN dotnet publish SteamTogether.Scraper/SteamTogether.Scraper.csproj \
     --configuration Release \
     --output /publish \
-    --no-restore
+    --no-restore \
+    /p:Version=$VERSION
 
 
 FROM runtime as scraper

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN dotnet publish SteamTogether.Bot/SteamTogether.Bot.csproj \
     --configuration Release \
     --output /publish \
     --no-restore \
-    /p:Version=$VERSION
+    -p:Version=$VERSION
 
 
 FROM runtime AS bot
@@ -51,7 +51,7 @@ RUN dotnet publish SteamTogether.Scraper/SteamTogether.Scraper.csproj \
     --configuration Release \
     --output /publish \
     --no-restore \
-    /p:Version=$VERSION
+    -p:Version=$VERSION
 
 
 FROM runtime as scraper

--- a/SteamTogether.Bot/SteamTogether.Bot.csproj
+++ b/SteamTogether.Bot/SteamTogether.Bot.csproj
@@ -5,20 +5,17 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>dotnet-SteamTogether.Bot-105EA173-BC5A-4BC2-B461-D84A1303C8FE</UserSecretsId>
     </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageReference Include="Telegram.Bot" Version="18.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-<PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" />
-
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" />
     </ItemGroup>
-
     <ItemGroup>
-      <ProjectReference Include="..\SteamTogether.Core\SteamTogether.Core.csproj" />
+        <ProjectReference Include="..\SteamTogether.Core\SteamTogether.Core.csproj" />
     </ItemGroup>
 </Project>

--- a/SteamTogether.Bot/TelegramPollingWorker.cs
+++ b/SteamTogether.Bot/TelegramPollingWorker.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using SteamTogether.Bot.Services;
 using SteamTogether.Core.Context;
@@ -16,9 +17,17 @@ public sealed class TelegramPollingWorker : BackgroundService
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         using var scope = _serviceProvider.CreateScope();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<TelegramPollingWorker>>();
+        logger.LogInformation(
+            "SteamTogether.Bot v{Version}",
+            Assembly
+                .GetExecutingAssembly()
+                .GetCustomAttributes<AssemblyInformationalVersionAttribute>()
+                .First()
+                .InformationalVersion
+        );
 
         var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-        var logger = scope.ServiceProvider.GetRequiredService<ILogger<TelegramPollingWorker>>();
         logger.LogInformation("Checking pending migrations");
 
         var pendingMigrations = await context.Database.GetPendingMigrationsAsync(cancellationToken);

--- a/SteamTogether.Bot/TelegramPollingWorker.cs
+++ b/SteamTogether.Bot/TelegramPollingWorker.cs
@@ -19,7 +19,8 @@ public sealed class TelegramPollingWorker : BackgroundService
         using var scope = _serviceProvider.CreateScope();
         var logger = scope.ServiceProvider.GetRequiredService<ILogger<TelegramPollingWorker>>();
         logger.LogInformation(
-            "SteamTogether.Bot v{Version}",
+            "{Name} v{Version}",
+            Assembly.GetExecutingAssembly().GetName().Name,
             Assembly
                 .GetExecutingAssembly()
                 .GetCustomAttributes<AssemblyInformationalVersionAttribute>()

--- a/SteamTogether.Scraper/Worker.cs
+++ b/SteamTogether.Scraper/Worker.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using SteamTogether.Core.Services;
 using SteamTogether.Scraper.Options;
 using SteamTogether.Scraper.Services;
+using System.Reflection;
 
 namespace SteamTogether.Scraper;
 
@@ -21,6 +22,16 @@ public class Worker : BackgroundService
         _serviceProvider = serviceProvider.CreateScope().ServiceProvider;
         _dateTimeService = dateTimeService;
         _logger = logger;
+
+        _logger.LogInformation(
+            "{Name} v{Version}",
+            Assembly.GetExecutingAssembly().GetName().Name,
+            Assembly
+                .GetExecutingAssembly()
+                .GetCustomAttributes<AssemblyInformationalVersionAttribute>()
+                .First()
+                .InformationalVersion
+        );
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,26 @@
+# https://taskfile.dev
+
+version: '3'
+
+silent: true
+
+tasks:
+  default: "${GOTASK_BIN:-task} --list"
+
+  compose:build:
+    desc: Build images with docker-compose
+    summary: Builds the images from the compose.yaml file.
+    cmds:
+      - docker-compose build
+    env:
+      VERSION:
+        sh: ./scripts/version.sh
+
+  compose:up:
+    desc: Start docker services with docker-compose
+    summary: Starts the docker services from the compose.yaml file.
+    cmds:
+      - docker-compose up -d
+    env:
+      VERSION:
+        sh: ./scripts/version.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,6 +1,6 @@
 # https://taskfile.dev
 
-version: '3'
+version: "3"
 
 silent: true
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,12 @@
 services:
   bot:
     build:
+      args:
+        - VERSION
       context: .
       dockerfile: Dockerfile
       target: bot
-    image: kudoser/steam-together-bot:${GIT_COMMIT:-latest}
+    image: kudoser/steam-together-bot:${VERSION:-latest}
     healthcheck:
       test: curl -fsSI http://localhost:${BOT_HEALTHCHECK__PORT:?} || exit 1
       interval: 10s
@@ -21,10 +23,12 @@ services:
 
   scraper:
     build:
+      args:
+        - VERSION
       context: .
       dockerfile: Dockerfile
       target: scraper
-    image: kudoser/steam-together-scraper:${GIT_COMMIT:-latest}
+    image: kudoser/steam-together-scraper:${VERSION:-latest}
     depends_on:
       - bot
     environment:

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script is used to generate a version string for the current commit.
+#
+# The format is:
+#   <tag>-<commits since tag>.<short sha>
+# or (if there is no tag):
+#   0.0.0-<commits since beginning>.<short sha>
+#
+# See https://learn.microsoft.com/en-us/nuget/concepts/package-versioning for
+# more information on versioning.
+
+TAG=$(git describe --abbrev=0 --tags 2>/dev/null)
+
+if [ -n "$TAG" ] && git describe --exact-match &>/dev/null; then
+    VERSION=$TAG
+else
+    SHORT_SHA=$(git rev-parse --short HEAD)
+    if [ -z "$TAG" ]; then
+        COMMITS_SINCE_BEGINNING=$(git rev-list --count HEAD 2>/dev/null)
+        VERSION="0.0.0-$COMMITS_SINCE_BEGINNING.$SHORT_SHA"
+    else
+        COMMITS_SINCE_TAG=$(git rev-list --count HEAD "^$TAG" 2>/dev/null)
+        VERSION="$TAG-$COMMITS_SINCE_TAG.$SHORT_SHA"
+    fi
+fi
+
+echo "$VERSION"


### PR DESCRIPTION
@ablizorukov Ideally, there should be `help` and `version` commands or `--help` and `--version` flags available on the executables. But I don't know what's the right way to implement such. That's why I just print the current version for now.